### PR TITLE
Take pointer on gdus call

### DIFF
--- a/client.c
+++ b/client.c
@@ -7,14 +7,14 @@ int main()
 {
 	MinMinBusGDBUS *proxy;
 	GError *error;
-	gchar **buf;
+	gchar *buf;
 
 	error = NULL;
 	proxy = min_min_bus_gdbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE,
 			"com.fatminmin", "/com/fatminmin/GDBUS", NULL, &error);
 
-	min_min_bus_gdbus_call_hello_world_sync(proxy, "fatminmin", buf, NULL, &error);
-	g_print("resp: %s\n", *buf);
+	min_min_bus_gdbus_call_hello_world_sync(proxy, "fatminmin", &buf, NULL, &error);
+	g_print("resp: %s\n", buf);
 
 	g_object_unref(proxy);
 	return 0;


### PR DESCRIPTION
# Take pointer on gdus call
I cant use this example without this change. 
It fails with this error:
`terminated by signal SIGSEGV (Address boundary error)`